### PR TITLE
Issue on paper site (read description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ demonstrating strengths in different aspects.
 
 **This repository contains the code used to produce the [results on the website](https://crfm.stanford.edu/heim/latest/) 
 and paper. To get started, refer to the [documentation](https://crfm-heim.readthedocs.io/).**
+
+ 


### PR DESCRIPTION
Forgive me for mal-using the pull request system, but seeing as theres no way to submit an issue...

On the paper site for heim https://crfm.stanford.edu/heim/v1.1.0/ the github repo that is linked on the button points to heLm not heIm

Spend a little while searching on the other repo for the image scoring and couldn't find it. 

Hopefully you whoever reading this either has permission to change it or knows the person that does. 



Either way, thanks for repo its proving to be very useful for an application I'm developing and for which I am grateful! 
~CB